### PR TITLE
Add compatibility to CAF benchmark suite

### DIFF
--- a/src/main/java/edu/rice/habanero/benchmarks/CliArgumentParser.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/CliArgumentParser.java
@@ -1,0 +1,92 @@
+package edu.rice.habanero.benchmarks;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.HashMap;
+
+/**
+ * @author <a href="https://github.com/aufgang001/">Sebastian Woelke</a> (aufgang001@posteo.de)
+ */
+public class CliArgumentParser {
+
+    private Map<String, String> cliArgs = new HashMap<>();
+
+    public CliArgumentParser(final String[] args) {
+        int i = 0;
+        while (i < args.length) {
+            String value = new String();
+            String key = args[i];
+            if (key.charAt(0) == '-') {
+                //it is an cli argument
+                int idx = key.indexOf('=');
+                if (idx != -1) {
+                    // is a value assigned with '='
+                    value = key.substring(idx + 1);
+                    key = key.substring(0, idx);
+                } else if ((i + 1) < args.length && args[i + 1].charAt(0) != '-') {
+                    // has next argument und is it a value
+                    value = args[i + 1];
+                    i++;
+                } else {
+                    // value must be a boolean 
+                    value = "true";
+                }
+          } else {
+              System.out.println("Command line argument expected but got value: "  + key);
+              System.exit(1);
+          }
+          cliArgs.put(key, value);
+          i++;
+        }
+    }
+  
+    private interface Parser<V> {
+        public V parse(String s);
+    };
+
+    private <V> V getValue(String[] key, V defaultValue, Parser<V> parser) {
+        for (int i = 0; i < key.length; ++i) {
+          String res = cliArgs.get(key[i]);
+          if (res != null) {
+              return parser.parse(res); 
+          }
+        }
+        return defaultValue;
+    }
+
+    public int getIntValue(String[] key, int defaultValue) {
+      Parser<Integer> parseInt = new Parser<Integer>() {
+          public Integer parse(String s) {
+              return Integer.parseInt(s);
+          }
+      };
+      return getValue(key, defaultValue, parseInt);
+    }
+
+    public long getLongValue(String[] key, long defaultValue) {
+      Parser<Long> parseLong = new Parser<Long>() {
+          public Long parse(String s) {
+              return Long.parseLong(s);
+          }
+      };
+      return getValue(key, defaultValue, parseLong);
+    }
+
+    public double getDoubleValue(String[] key, double defaultValue) {
+      Parser<Double> parseDouble = new Parser<Double>() {
+          public Double parse(String s) {
+              return Double.parseDouble(s);
+          }
+      };
+      return getValue(key, defaultValue, parseDouble);
+    }
+
+    public boolean getBoolValue(String[] key, boolean defaultValue) {
+      Parser<Boolean> parseBool = new Parser<Boolean>() {
+          public Boolean parse(String s) {
+              return Boolean.parseBoolean(s);
+          }
+      };
+      return getValue(key, defaultValue, parseBool);
+    }
+}

--- a/src/main/java/edu/rice/habanero/benchmarks/apsp/ApspConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/apsp/ApspConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.apsp;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -13,29 +14,11 @@ public final class ApspConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-b":
-                    i += 1;
-                    B = Integer.parseInt(args[i]);
-                    break;
-                case "-w":
-                    i += 1;
-                    W = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        B = ap.getIntValue(new String[] {"-b"}, B);
+        W = ap.getIntValue(new String[] {"-w"}, W);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/astar/GuidedSearchConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/astar/GuidedSearchConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.astar;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
@@ -19,37 +20,20 @@ public final class GuidedSearchConfig {
     private static Map<Integer, GridNode> allNodes = null;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-w":
-                    i += 1;
-                    NUM_WORKERS = Integer.parseInt(args[i]);
-                    break;
-                case "-t":
-                    i += 1;
-                    THRESHOLD = Integer.parseInt(args[i]);
-                    break;
-                case "-g":
-                    i += 1;
-                    final int userInput = Integer.parseInt(args[i]);
-                    final int allowedMax = (MessagePriority.values().length - 1) * PRIORITY_GRANULARITY;
-                    GRID_SIZE = Math.min(userInput, allowedMax);
-                    break;
-                case "-p":
-                    i += 1;
-                    final int priority = Integer.parseInt(args[i]);
-                    final int maxPriority = MessagePriority.values().length - 1;
-                    PRIORITIES = Math.max(1, Math.min(priority, maxPriority));
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
+        CliArgumentParser ap = new CliArgumentParser(args);
+        NUM_WORKERS = ap.getIntValue(new String[] {"-w"}, NUM_WORKERS);
+        THRESHOLD = ap.getIntValue(new String[] {"-t"}, THRESHOLD);
+        {
+            final int userInput = ap.getIntValue(new String[] {"-g"}, GRID_SIZE);
+            final int allowedMax = (MessagePriority.values().length - 1) * PRIORITY_GRANULARITY;
+            GRID_SIZE = Math.min(userInput, allowedMax);
         }
+        {
+            final int priority = ap.getIntValue(new String[] {"-p"}, PRIORITIES);
+            final int maxPriority = MessagePriority.values().length - 1;
+            PRIORITIES = Math.max(1, Math.min(priority, maxPriority));
+        }
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
 
         initializeData();
     }

--- a/src/main/java/edu/rice/habanero/benchmarks/banking/BankingConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/banking/BankingConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.banking;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -13,25 +14,10 @@ public final class BankingConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-a":
-                    i += 1;
-                    A = Integer.parseInt(args[i]);
-                    break;
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        A = ap.getIntValue(new String[] {"-a"}, A);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
 
         INITIAL_BALANCE = ((Double.MAX_VALUE / (A * N)) / 1_000) * 1_000;
     }

--- a/src/main/java/edu/rice/habanero/benchmarks/barber/SleepingBarberConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/barber/SleepingBarberConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.barber;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -14,26 +15,12 @@ public final class SleepingBarberConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            if ("-n".equals(loopOptionKey)) {
-                i += 1;
-                N = Integer.parseInt(args[i]);
-            } else if ("-w".equals(loopOptionKey)) {
-                i += 1;
-                W = Integer.parseInt(args[i]);
-            } else if ("-pr".equals(loopOptionKey)) {
-                i += 1;
-                APR = Integer.parseInt(args[i]);
-            } else if ("-hr".equals(loopOptionKey)) {
-                i += 1;
-                AHR = Integer.parseInt(args[i]);
-            } else if ("-debug".equals(loopOptionKey) || "-verbose".equals(loopOptionKey)) {
-                debug = true;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        W = ap.getIntValue(new String[] {"-w"}, W);
+        APR = ap.getIntValue(new String[] {"-pr", "-p"}, APR);
+        AHR = ap.getIntValue(new String[] {"-hr", "-c"}, AHR);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/big/BigConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/big/BigConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.big;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -12,20 +13,10 @@ public final class BigConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            if ("-n".equals(loopOptionKey)) {
-                i += 1;
-                N = Integer.parseInt(args[i]);
-            } else if ("-w".equals(loopOptionKey)) {
-                i += 1;
-                W = Integer.parseInt(args[i]);
-            } else if ("-debug".equals(loopOptionKey) || "-verbose".equals(loopOptionKey)) {
-                debug = true;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        W = ap.getIntValue(new String[] {"-w"}, W);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/bitonicsort/BitonicSortConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/bitonicsort/BitonicSortConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.bitonicsort;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -13,29 +14,11 @@ public final class BitonicSortConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-m":
-                    i += 1;
-                    M = Long.parseLong(args[i]);
-                    break;
-                case "-s":
-                    i += 1;
-                    S = Long.parseLong(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        M = ap.getLongValue(new String[] {"-m"}, M);
+        S = ap.getLongValue(new String[] {"-s"}, S);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/bndbuffer/ProdConsBoundedBufferConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/bndbuffer/ProdConsBoundedBufferConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.bndbuffer;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 import edu.rice.habanero.benchmarks.PseudoRandom;
 
 /**
@@ -20,49 +21,15 @@ public final class ProdConsBoundedBufferConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-
-            switch (loopOptionKey) {
-                case "-bb":
-                    i += 1;
-                    bufferSize = Integer.parseInt(args[i]);
-                    break;
-                case "-np":
-                    i += 1;
-                    numProducers = Integer.parseInt(args[i]);
-                    break;
-                case "-nc":
-                    i += 1;
-                    numConsumers = Integer.parseInt(args[i]);
-                    break;
-                case "-pc":
-                    i += 1;
-                    prodCost = Integer.parseInt(args[i]);
-                    break;
-                case "-cc":
-                    i += 1;
-                    consCost = Integer.parseInt(args[i]);
-                    break;
-                case "-ipp":
-                    i += 1;
-                    numItemsPerProducer = Integer.parseInt(args[i]);
-                    break;
-                case "-numChannels":
-                case "-numMailboxes":
-                case "-nm":
-                    i += 1;
-                    numMailboxes = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        bufferSize = ap.getIntValue(new String[] {"-bb", "-b"}, bufferSize);
+        numProducers = ap.getIntValue(new String[] {"-np", "-p"}, numProducers);
+        numConsumers = ap.getIntValue(new String[] {"-nc", "-c"}, numConsumers);
+        prodCost = ap.getIntValue(new String[] {"-pc", "-x"}, prodCost);
+        consCost = ap.getIntValue(new String[] {"-cc", "-y"}, consCost);
+        numItemsPerProducer = ap.getIntValue(new String[] {"-ipp", "-i"}, numItemsPerProducer);
+        numMailboxes = ap.getIntValue(new String[] {"-numChannels", "-numMailboxes", "-nm"}, numMailboxes);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/chameneos/ChameneosConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/chameneos/ChameneosConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.chameneos;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -14,39 +15,12 @@ public final class ChameneosConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-
-            switch (loopOptionKey) {
-                case "-numChameneos":
-                case "-c":
-                    i += 1;
-                    numChameneos = Integer.parseInt(args[i]);
-                    break;
-                case "-numMeetings":
-                case "-m":
-                    i += 1;
-                    numMeetings = Integer.parseInt(args[i]);
-                    break;
-                case "-numChannels":
-                case "-numMailboxes":
-                case "-nm":
-                    i += 1;
-                    numMailboxes = Integer.parseInt(args[i]);
-                    break;
-                case "-p":
-                    i += 1;
-                    usePriorities = Boolean.parseBoolean(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        numChameneos = ap.getIntValue(new String[] {"-numChameneos", "-c"}, numChameneos);
+        numMeetings = ap.getIntValue(new String[] {"-numMeetings", "-m"}, numMeetings);
+        numMailboxes = ap.getIntValue(new String[] {"-numChannels", "-numMailboxes", "-nm"}, numMailboxes);
+        usePriorities = ap.getBoolValue(new String[] {"-p"}, usePriorities);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/cigsmok/CigaretteSmokerConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/cigsmok/CigaretteSmokerConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.cigsmok;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -12,20 +13,10 @@ public final class CigaretteSmokerConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            if ("-r".equals(loopOptionKey)) {
-                i += 1;
-                R = Integer.parseInt(args[i]);
-            } else if ("-s".equals(loopOptionKey)) {
-                i += 1;
-                S = Integer.parseInt(args[i]);
-            } else if ("-debug".equals(loopOptionKey) || "-verbose".equals(loopOptionKey)) {
-                debug = true;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        R = ap.getIntValue(new String[] {"-r"}, R);
+        S = ap.getIntValue(new String[] {"-s"}, S);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/concdict/DictionaryConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/concdict/DictionaryConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.concdict;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -20,29 +21,11 @@ public final class DictionaryConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-e":
-                    i += 1;
-                    NUM_ENTITIES = Integer.parseInt(args[i]);
-                    break;
-                case "-m":
-                    i += 1;
-                    NUM_MSGS_PER_WORKER = Integer.parseInt(args[i]);
-                    break;
-                case "-w":
-                    i += 1;
-                    WRITE_PERCENTAGE = Integer.parseInt(args[i]);
-                    break;
-                case "debug":
-                case "verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        NUM_ENTITIES = ap.getIntValue(new String[] {"-e"}, NUM_ENTITIES);
+        NUM_MSGS_PER_WORKER = ap.getIntValue(new String[] {"-m"}, NUM_MSGS_PER_WORKER);
+        WRITE_PERCENTAGE = ap.getIntValue(new String[] {"-w"}, WRITE_PERCENTAGE);
+        debug = ap.getBoolValue(new String[]{"--debug", "--verbose"}, debug);
 
         for (int k = 0; k < DATA_LIMIT; k++) {
             DATA_MAP.put(k, k);

--- a/src/main/java/edu/rice/habanero/benchmarks/concsll/SortedListConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/concsll/SortedListConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.concsll;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -15,33 +16,12 @@ public final class SortedListConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-e":
-                    i += 1;
-                    NUM_ENTITIES = Integer.parseInt(args[i]);
-                    break;
-                case "-m":
-                    i += 1;
-                    NUM_MSGS_PER_WORKER = Integer.parseInt(args[i]);
-                    break;
-                case "-w":
-                    i += 1;
-                    WRITE_PERCENTAGE = Integer.parseInt(args[i]);
-                    break;
-                case "-s":
-                    i += 1;
-                    SIZE_PERCENTAGE = Integer.parseInt(args[i]);
-                    break;
-                case "debug":
-                case "verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        NUM_ENTITIES = ap.getIntValue(new String[] {"-e"}, NUM_ENTITIES);
+        NUM_MSGS_PER_WORKER = ap.getIntValue(new String[] {"-m"}, NUM_MSGS_PER_WORKER);
+        WRITE_PERCENTAGE = ap.getIntValue(new String[] {"-w"}, WRITE_PERCENTAGE);
+        SIZE_PERCENTAGE = ap.getIntValue(new String[] {"-s"}, SIZE_PERCENTAGE);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
 
         if (WRITE_PERCENTAGE >= 50) {
             throw new IllegalArgumentException("Write rate must be less than 50!");

--- a/src/main/java/edu/rice/habanero/benchmarks/count/CountingConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/count/CountingConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.count;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -11,21 +12,9 @@ public final class CountingConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/facloc/FacilityLocationConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/facloc/FacilityLocationConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.facloc;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 import edu.rice.habanero.benchmarks.PseudoRandom;
 
 import java.util.*;
@@ -22,29 +23,14 @@ public final class FacilityLocationConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            if ("-n".equals(loopOptionKey)) {
-                i += 1;
-                NUM_POINTS = Integer.parseInt(args[i]);
-            } else if ("-g".equals(loopOptionKey)) {
-                i += 1;
-                GRID_SIZE = java.lang.Double.parseDouble(args[i]);
-            } else if ("-a".equals(loopOptionKey)) {
-                i += 1;
-                ALPHA = java.lang.Double.parseDouble(args[i]);
-            } else if ("-s".equals(loopOptionKey)) {
-                i += 1;
-                SEED = java.lang.Long.parseLong(args[i]);
-            } else if ("-c".equals(loopOptionKey)) {
-                i += 1;
-                CUTOFF_DEPTH = Integer.parseInt(args[i]);
-            } else if ("-debug".equals(loopOptionKey) || "-verbose".equals(loopOptionKey)) {
-                debug = true;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        NUM_POINTS = ap.getIntValue(new String[] {"-n"}, NUM_POINTS);
+        GRID_SIZE = ap.getDoubleValue(new String[] {"-g"}, GRID_SIZE);
+        ALPHA = ap.getDoubleValue(new String[] {"-a"}, ALPHA);
+        SEED = ap.getLongValue(new String[] {"-s"}, SEED);
+        CUTOFF_DEPTH = ap.getIntValue(new String[] {"-c"}, CUTOFF_DEPTH);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
+
         F = Math.sqrt(2) * GRID_SIZE;
     }
 

--- a/src/main/java/edu/rice/habanero/benchmarks/fib/FibonacciConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/fib/FibonacciConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.fib;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -11,21 +12,9 @@ public final class FibonacciConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/filterbank/FilterBankConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/filterbank/FilterBankConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.filterbank;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 import java.util.Collection;
 
@@ -20,39 +21,20 @@ public final class FilterBankConfig {
     protected static double[][] F = null;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-sim":
-                case "-simulation":
-                    i += 1;
-                    NUM_SIMULATIONS = Integer.parseInt(args[i]);
-                    break;
-                case "-col":
-                case "-columns":
-                    i += 1;
-                    NUM_COLUMNS = Integer.parseInt(args[i]);
-                    break;
-                case "-chan":
-                case "-channels":
-                    i += 1;
-                    final int argInt = Integer.parseInt(args[i]);
-                    final int maxChannels = MessageChannel.values().length - 1;
-                    NUM_CHANNELS = Math.max(2, Math.min(argInt, maxChannels));
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
+        CliArgumentParser ap = new CliArgumentParser(args);
+        NUM_SIMULATIONS = ap.getIntValue(new String[]{"-s", "-sim", "-simulation"}, NUM_SIMULATIONS);
+        NUM_COLUMNS = ap.getIntValue(new String[]{"-c", "-col", "-columns"}, NUM_COLUMNS);
+        {
+            final int argInt = ap.getIntValue(new String[]{"-a", "-chan", "-channels"}, NUM_CHANNELS);
+            final int maxChannels = MessageChannel.values().length - 1;
+            NUM_CHANNELS = Math.max(2, Math.min(argInt, maxChannels));
         }
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
 
         H = new double[NUM_CHANNELS][NUM_COLUMNS];
         F = new double[NUM_CHANNELS][NUM_COLUMNS];
         for (int j = 0; j < NUM_CHANNELS; j++) {
-            for (i = 0; i < NUM_COLUMNS; i++) {
+            for (int i = 0; i < NUM_COLUMNS; i++) {
                 H[j][i] = (1.0 * i * NUM_COLUMNS) + (1.0 * j * NUM_CHANNELS) + j + i + j + 1;
                 F[j][i] = (1.0 * i * j) + (1.0 * j * j) + j + i;
             }

--- a/src/main/java/edu/rice/habanero/benchmarks/fjcreate/ForkJoinConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/fjcreate/ForkJoinConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.fjcreate;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -12,25 +13,10 @@ public final class ForkJoinConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-c":
-                    i += 1;
-                    C = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        C = ap.getIntValue(new String[] {"-c"}, C);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/fjthrput/ThroughputConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/fjthrput/ThroughputConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.fjthrput;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -14,33 +15,12 @@ public final class ThroughputConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-a":
-                    i += 1;
-                    A = Integer.parseInt(args[i]);
-                    break;
-                case "-c":
-                    i += 1;
-                    C = Integer.parseInt(args[i]);
-                    break;
-                case "-p":
-                    i += 1;
-                    usePriorities = Boolean.parseBoolean(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        A = ap.getIntValue(new String[] {"-a"}, A);
+        C = ap.getIntValue(new String[] {"-c"}, C);
+        usePriorities = ap.getBoolValue(new String[] {"-p"}, usePriorities);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/logmap/LogisticMapConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/logmap/LogisticMapConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.logmap;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * Computes Logistic Map source: http://en.wikipedia.org/wiki/Logistic_map
@@ -16,31 +17,11 @@ public final class LogisticMapConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-
-            switch (loopOptionKey) {
-                case "-t":
-                    i += 1;
-                    numTerms = Integer.parseInt(args[i]);
-                    break;
-                case "-s":
-                    i += 1;
-                    numSeries = Integer.parseInt(args[i]);
-                    break;
-                case "-r":
-                    i += 1;
-                    startRate = Double.parseDouble(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        numTerms = ap.getIntValue(new String[] {"-t"}, numTerms);
+        numSeries = ap.getIntValue(new String[] {"-s"}, numSeries);
+        startRate = ap.getDoubleValue(new String[] {"-r"}, startRate);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/nqueenk/NQueensConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/nqueenk/NQueensConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.nqueenk;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -39,39 +40,23 @@ public final class NQueensConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    SIZE = Math.max(1, Math.min(Integer.parseInt(args[i]), MAX_SOLUTIONS));
-                    break;
-                case "-t":
-                    i += 1;
-                    THRESHOLD = Math.max(1, Math.min(Integer.parseInt(args[i]), MAX_SOLUTIONS));
-                    break;
-                case "-w":
-                    i += 1;
-                    NUM_WORKERS = Integer.parseInt(args[i]);
-                    break;
-                case "-s":
-                    i += 1;
-                    SOLUTIONS_LIMIT = Integer.parseInt(args[i]);
-                    break;
-                case "-p":
-                    i += 1;
-                    final int priority = Integer.parseInt(args[i]);
-                    final int maxPriority = MessagePriority.values().length - 1;
-                    PRIORITIES = Math.max(1, Math.min(priority, maxPriority));
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
+        CliArgumentParser ap = new CliArgumentParser(args);
+        {
+            final int userInput = ap.getIntValue(new String[] {"-n"}, SIZE);
+            SIZE = Math.max(1, Math.min(userInput, MAX_SOLUTIONS));
         }
+        {
+            final int userInput = ap.getIntValue(new String[] {"-t"}, THRESHOLD);
+            THRESHOLD = Math.max(1, Math.min(userInput, MAX_SOLUTIONS));
+        }
+        NUM_WORKERS = ap.getIntValue(new String[] {"-w"}, NUM_WORKERS);
+        SOLUTIONS_LIMIT = ap.getIntValue(new String[] {"-s"}, SOLUTIONS_LIMIT);
+        {
+            final int priority = ap.getIntValue(new String[] {"-p"}, PRIORITIES);
+            final int maxPriority = MessagePriority.values().length - 1;
+            PRIORITIES = Math.max(1, Math.min(priority, maxPriority));
+        }
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/philosopher/PhilosopherConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/philosopher/PhilosopherConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.philosopher;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -13,29 +14,11 @@ public final class PhilosopherConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-m":
-                    i += 1;
-                    M = Integer.parseInt(args[i]);
-                    break;
-                case "-c":
-                    i += 1;
-                    C = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        M = ap.getIntValue(new String[] {"-m"}, M);
+        C = ap.getIntValue(new String[] {"-c"}, C);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/pingpong/PingPongConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/pingpong/PingPongConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.pingpong;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -11,17 +12,9 @@ public final class PingPongConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            if ("-n".equals(loopOptionKey)) {
-                i += 1;
-                N = Integer.parseInt(args[i]);
-            } else if ("-debug".equals(loopOptionKey) || "-verbose".equals(loopOptionKey)) {
-                debug = true;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/piprecision/PiPrecisionConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/piprecision/PiPrecisionConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.piprecision;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -19,25 +20,10 @@ public final class PiPrecisionConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-w":
-                    i += 1;
-                    NUM_WORKERS = Integer.parseInt(args[i]);
-                    break;
-                case "-p":
-                    i += 1;
-                    PRECISION = Integer.parseInt(args[i]);
-                    break;
-                case "debug":
-                case "verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        NUM_WORKERS = ap.getIntValue(new String[] {"-w"}, NUM_WORKERS);
+        PRECISION = ap.getIntValue(new String[] {"-p"}, PRECISION);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/quicksort/QuickSortConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/quicksort/QuickSortConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.quicksort;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 import edu.rice.habanero.benchmarks.PseudoRandom;
 
 import java.util.ArrayList;
@@ -18,33 +19,12 @@ public final class QuickSortConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-m":
-                    i += 1;
-                    M = Long.parseLong(args[i]);
-                    break;
-                case "-t":
-                    i += 1;
-                    T = Long.parseLong(args[i]);
-                    break;
-                case "-s":
-                    i += 1;
-                    S = Long.parseLong(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        M = ap.getLongValue(new String[] {"-m"}, M);
+        T = ap.getLongValue(new String[] {"-t"}, T);
+        S = ap.getLongValue(new String[] {"-s"}, S);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/radixsort/RadixSortConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/radixsort/RadixSortConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.radixsort;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -13,29 +14,11 @@ public final class RadixSortConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-m":
-                    i += 1;
-                    M = Long.parseLong(args[i]);
-                    break;
-                case "-s":
-                    i += 1;
-                    S = Long.parseLong(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        M = ap.getLongValue(new String[] {"-m"}, M);
+        S = ap.getLongValue(new String[] {"-s"}, S);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/recmatmul/MatMulConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/recmatmul/MatMulConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.recmatmul;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -18,35 +19,16 @@ public final class MatMulConfig {
     protected static double[][] C = null;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    DATA_LENGTH = Integer.parseInt(args[i]);
-                    break;
-                case "-t":
-                    i += 1;
-                    BLOCK_THRESHOLD = Integer.parseInt(args[i]);
-                    break;
-                case "-w":
-                    i += 1;
-                    NUM_WORKERS = Integer.parseInt(args[i]);
-                    break;
-                case "-p":
-                    i += 1;
-                    final int priority = Integer.parseInt(args[i]);
-                    final int maxPriority = MessagePriority.values().length - 1;
-                    PRIORITIES = Math.max(1, Math.min(priority, maxPriority));
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
+        CliArgumentParser ap = new CliArgumentParser(args);
+        DATA_LENGTH = ap.getIntValue(new String[] {"-n"}, DATA_LENGTH);
+        BLOCK_THRESHOLD = ap.getIntValue(new String[] {"-t"}, BLOCK_THRESHOLD);
+        NUM_WORKERS = ap.getIntValue(new String[] {"-w"}, NUM_WORKERS);
+        {
+            final int priority = ap.getIntValue(new String[] {"-p"}, PRIORITIES);
+            final int maxPriority = MessagePriority.values().length - 1;
+            PRIORITIES = Math.max(1, Math.min(priority, maxPriority));
         }
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
 
         initializeData();
     }

--- a/src/main/java/edu/rice/habanero/benchmarks/sieve/SieveConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/sieve/SieveConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.sieve;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -12,25 +13,10 @@ public final class SieveConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Long.parseLong(args[i]);
-                    break;
-                case "-m":
-                    i += 1;
-                    M = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getLongValue(new String[] {"-n"}, N);
+        M = ap.getIntValue(new String[] {"-m"}, M);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/sor/SucOverRelaxConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/sor/SucOverRelaxConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.sor;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 import edu.rice.habanero.benchmarks.PseudoRandom;
 
 /**
@@ -29,21 +30,9 @@ public final class SucOverRelaxConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/threadring/ThreadRingConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/threadring/ThreadRingConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.threadring;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -12,20 +13,10 @@ public final class ThreadRingConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            if ("-n".equals(loopOptionKey)) {
-                i += 1;
-                N = Integer.parseInt(args[i]);
-            } else if ("-r".equals(loopOptionKey)) {
-                i += 1;
-                R = Integer.parseInt(args[i]);
-            } else if ("-debug".equals(loopOptionKey) || "-verbose".equals(loopOptionKey)) {
-                debug = true;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        R = ap.getIntValue(new String[] {"-r"}, R);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/trapezoid/TrapezoidalConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/trapezoid/TrapezoidalConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.trapezoid;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * @author <a href="http://shams.web.rice.edu/">Shams Imam</a> (shams@rice.edu)
@@ -14,33 +15,12 @@ public final class TrapezoidalConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-            switch (loopOptionKey) {
-                case "-n":
-                    i += 1;
-                    N = Integer.parseInt(args[i]);
-                    break;
-                case "-w":
-                    i += 1;
-                    W = Integer.parseInt(args[i]);
-                    break;
-                case "-l":
-                    i += 1;
-                    L = Double.parseDouble(args[i]);
-                    break;
-                case "-r":
-                    i += 1;
-                    R = Double.parseDouble(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        N = ap.getIntValue(new String[] {"-n"}, N);
+        W = ap.getIntValue(new String[] {"-w"}, W);
+        L = ap.getDoubleValue(new String[] {"-l"}, L);
+        R = ap.getDoubleValue(new String[] {"-r"}, R);
+        debug = ap.getBoolValue(new String[] {"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {

--- a/src/main/java/edu/rice/habanero/benchmarks/uct/UctConfig.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/uct/UctConfig.java
@@ -1,6 +1,7 @@
 package edu.rice.habanero.benchmarks.uct;
 
 import edu.rice.habanero.benchmarks.BenchmarkRunner;
+import edu.rice.habanero.benchmarks.CliArgumentParser;
 
 /**
  * Unbalanced Cobwebbed Tree benchmark.
@@ -17,39 +18,13 @@ public final class UctConfig {
     protected static boolean debug = false;
 
     protected static void parseArgs(final String[] args) {
-        int i = 0;
-        while (i < args.length) {
-            final String loopOptionKey = args[i];
-
-            switch (loopOptionKey) {
-                case "-nodes":
-                    i += 1;
-                    MAX_NODES = Integer.parseInt(args[i]);
-                    break;
-                case "-avg":
-                    i += 1;
-                    AVG_COMP_SIZE = Integer.parseInt(args[i]);
-                    break;
-                case "-stdev":
-                    i += 1;
-                    STDEV_COMP_SIZE = Integer.parseInt(args[i]);
-                    break;
-                case "-binomial":
-                    i += 1;
-                    BINOMIAL_PARAM = Integer.parseInt(args[i]);
-                    break;
-                case "-urgent":
-                    i += 1;
-                    URGENT_NODE_PERCENT = Integer.parseInt(args[i]);
-                    break;
-                case "-debug":
-                case "-verbose":
-                    debug = true;
-                    break;
-            }
-
-            i += 1;
-        }
+        CliArgumentParser ap = new CliArgumentParser(args);
+        MAX_NODES = ap.getIntValue(new String[]{"-n", "-nodes"}, MAX_NODES);
+        AVG_COMP_SIZE = ap.getIntValue(new String[]{"-a", "-avg"}, AVG_COMP_SIZE);
+        STDEV_COMP_SIZE = ap.getIntValue(new String[]{"-s", "-stdev"}, STDEV_COMP_SIZE);
+        BINOMIAL_PARAM = ap.getIntValue(new String[]{"-b", "-binomial"}, BINOMIAL_PARAM);
+        URGENT_NODE_PERCENT = ap.getIntValue(new String[]{"-u", "-urgent"}, URGENT_NODE_PERCENT);
+        debug = ap.getBoolValue(new String[]{"--debug", "--verbose"}, debug);
     }
 
     protected static void printArgs() {
@@ -63,7 +38,6 @@ public final class UctConfig {
 
     protected static int loop(int busywait, int dummy) {
         int test = 0;
-        long current = System.currentTimeMillis();
 
         for (int k = 0; k < dummy * busywait; k++) {
             test++;


### PR DESCRIPTION
Existing scripts which uses savina are not effected by this pull request.
CLI Arguments are now handled by the class CliArgumentParser, which generalises and simplifies parsing of arguments.
And a new CLI arg for the benchmark runner is added (--no_evaluation) which deactivates performance calculations and output.
