### PR TITLE
add -workers CLI option for specifying the number of workers

### DIFF
--- a/src/main/java/edu/rice/habanero/benchmarks/BenchmarkRunner.java
+++ b/src/main/java/edu/rice/habanero/benchmarks/BenchmarkRunner.java
@@ -33,6 +33,11 @@ public class BenchmarkRunner {
             if (argName.equalsIgnoreCase("-iter")) {
                 iterations = Integer.parseInt(argValue);
             }
+
+            if (argName.equalsIgnoreCase("-workers")) {
+                System.setProperty("actors.corePoolSize", argValue);
+                System.setProperty("actors.maxPoolSize", argValue);
+            }
         }
     }
 
@@ -59,6 +64,7 @@ public class BenchmarkRunner {
         System.out.printf(argOutputFormat, "O/S Version", System.getProperty("os.version"));
         System.out.printf(argOutputFormat, "O/S Name", System.getProperty("os.name"));
         System.out.printf(argOutputFormat, "O/S Arch", System.getProperty("os.arch"));
+        System.out.printf(argOutputFormat, "Num workers", System.getProperty("actors.corePoolSize"));
 
         final List<Double> rawExecTimes = new ArrayList<>(iterations);
 


### PR DESCRIPTION
This is a simple change adding a `-workers` CLI argument that allows to override the default number of workers. This is particularly useful for analyzing the scaling behavior of certain benchmarks.